### PR TITLE
Typos in top-level files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,18 +1,18 @@
 2.1.1.1
-  * Fix bug #1300172 WMI GetLoggedOnUser blocking and CPU full on OCS 2.1.0.3. Agent may sometimes produce 100% CPU during many minutes, when retrieving logged on users from WMI. Install these patchs from Microsoft solves the problem:
-		For windows 2003 SP2: http://support.microsoft.com/kb/2257980/en
-		For Winows 2008 : http://support.microsoft.com/kb/2464876/en
-		For windows 2008 R2: http://support.microsoft.com/kb/2465990/en
-	Anyway, I advice to run all this KB to fix WMI performance or errors: http://support.microsoft.com/kb/2591403
+  * Fix bug #1300172 WMI GetLoggedOnUser blocking and CPU full on OCS 2.1.0.3. Agent may sometimes produce 100% CPU during many minutes, when retrieving logged on users from WMI. Install these patches from Microsoft solves the problem:
+		For Windows 2003 SP2: http://support.microsoft.com/kb/2257980/en
+		For Windows 2008 : http://support.microsoft.com/kb/2464876/en
+		For Windows 2008 R2: http://support.microsoft.com/kb/2465990/en
+	Anyway, I advise to run all this KB to fix WMI performance or errors: http://support.microsoft.com/kb/2591403
   * Fix bug #1300172: Agent uses 100% CPU on TSC servers and DC
   * Fix bug #1292465: Do not try to unregister from service manager if not installed
   * Fix bug #1292020 Windows Agent 2.1.0.3 doesn't report User 
 2.1.0.4
   * Get DMI data using OcsWmi DLL, instead of using own WMI code
   * Fix bug #1062582 Windows agent leaks handles by initializing COM and COM Security into main executable, instead of DLL
-  * Enable more detailled debug logs, and fixes small issues
+  * Enable more detailed debug logs, and fixes small issues
 2.1.0.3
-  * Fix XSLT for displaying CPU into "show computer information" command of systrau applet
+  * Fix XSLT for displaying CPU into "show computer information" command of systray applet
   * Fix Processor S/N filled with CPU Status if no serial number exist
   * Better handling of potentially not well formatted data, to avoid application crash
 2.1.0.2
@@ -25,11 +25,11 @@
   * Fix Bug #1217435: Packager tries to shutdown ocs service twice when upgrading from 1.X agent
   * Fix bug displaying before installation user notification at the end of installation, instead of post installation notification text
   * Add package command start date/time and timeout date/time to log
-  * Fix bug #1184426: Retreive processor Serial Number
+  * Fix bug #1184426: Retrieve processor Serial Number
   * Fix bug disabling ability to control command execution timeout from server
-  * Try to retreive CPU S/N using WMI
+  * Try to retrieve CPU S/N using WMI
   * There is now DMI table type greater than 127, so remove type lower and upper bound check
-  * WMI meory bank type codes are not the same as DMI codes
+  * WMI memory bank type codes are not the same as DMI codes
   * Add printer information (Print server name and share, resolution, comment, Is printer shared, Is printer on network)
   * Update DtWinver to version 1.88 to support Windows Blue
   * Fix bug ID #1178946: Get logged on user and domain from WMI first                              
@@ -43,21 +43,21 @@
   * Add agent ability to force package reinstall, and support for package setup schedule
   * Fix bug #1086324: download.exe crashes when NOTIFY_TIMEOUT is not set. So ensure value is provided
   * Fix bug #1086972: Windows Agent 2.0.5.3 does not inventory any BIOS information - 2.0.5.2 does
-  * Include lastest list of PNPID vendors, for EDID monitors (see http://www.vesa.org/vesa-standards/standards-faq/))
-  * Allow using HTML formating for deployement notification, pre and post package execution
-  * Workaround bug #1048955: Restrict german language to German/Germany locale
+  * Include latest list of PNPID vendors, for EDID monitors (see http://www.vesa.org/vesa-standards/standards-faq/))
+  * Allow using HTML formatting for deployment notification, pre and post package execution
+  * Workaround bug #1048955: Restrict German language to German/Germany locale
   * Fix bug #1034821: Also compute checksum for plugin output, to allow detecting changes when plugin update standard inventory informations like software
   * Try to utf-8 encode VBS or EXE plugin output if XML parsing fails, then try again to parse
   * Fix bug #1049864: When agent load configuration, it now really uses authRequired and proxyauthRequired values, and not set them to FALSE by default
   * Fix bug #1045784: Ensure timestamp exists before verify expiration
-  * Add download error to differenciate full download timeout ERR_TIMEOUT, execute error crashing agent and entering in loop (ERR_EXECUTE_TOO_MANY_TRY) or execute timeout (ERR_EXECUTE_TIMEOUT).
+  * Add download error to differentiate full download timeout ERR_TIMEOUT, execute error crashing agent and entering in loop (ERR_EXECUTE_TOO_MANY_TRY) or execute timeout (ERR_EXECUTE_TIMEOUT).
   * Rename ERR_ALREADY_SETUP en SUCCESS_ALREADY_SETUP 
-  * Bug #1031935: Windows MAK or VLK activation key are not stored on computer, so unable to retreive and set explicit message
+  * Bug #1031935: Windows MAK or VLK activation key are not stored on computer, so unable to retrieve and set explicit message
   * Fix bug #980740: As we only read process output each 200ms, we have to read output even after process exited, to capture last outputed data by process
 2.0.5.0
   * Enhanced dynamic DLL plugin API
-  * Allow to start Systray applet in the finish page of installer, as it is no more automatically lauched
-  * Prompt user for TAG using OcsNotifyUser tool and optimze User notification code
+  * Allow to start Systray applet in the finish page of installer, as it is no more automatically launched
+  * Prompt user for TAG using OcsNotifyUser tool and optimize User notification code
   * Fix bug #104079: Try to check if part of memory is used by video, either less than 32 MB or less than 10%
   * Fix bug in ACER display's serial number retrieval
   * Do not launch OcsSystray at the end of setup, to avoid it running under system account when agent is upgraded using agent itself and package deployment
@@ -71,21 +71,21 @@
   * Fix bug #820209: Add Windows firewall rules for OCS Inventory NG, only if firewall is enabled
   * Fix bug #1021367: Set Max Error allowed to 5 consecutive errors instead of 30, and also uses this parameter into package execution. Package will return ERR_EXECUTE_PACK if execution fails more then MAX_ERROR_COUNT set to 5. Also uses a timeout into command execution (default 120 minutes)
   * Fix big #1015434 : Try to also search for package ID file in installer parent directory
-  * Avoid sending ERR_ALREADY_SETUP after agent upgrade using deployement. This is done by movng agent's setup result code file to package directory
+  * Avoid sending ERR_ALREADY_SETUP after agent upgrade using deployment. This is done by moving agent's setup result code file to package directory
   * Fix bug #1028353: Add EDID code FUJ, TOS, MS_, NVD, END, CPT, LGD et LEN for EDID monitor  
-  * Fix bug #948155: Validation message popup are not localized in english, german, spanish and french
+  * Fix bug #948155: Validation message popup are not localized in English, German, Spanish and French
   * Fix bug #929549: By default, server authentication not required unless user or proxy option specified, and proxy authentication not required unless proxy_user or proxy_pwd option specified
   * Fix bug #943182: Copying History file from <$INSTDIR\download> to <$APPDATA\OCS Inventory NG\Agent>
   * Fix bug #948172: Validation message popup comes up in foreground, but not activated
-  * Bug #966320: Disable redirection immediately prior to the native API function call if compiled for Windows XP or higher. However, agent 2.0 supports Windows 2000, and this fix only apply if compiled without Windows 2000 support, but only Windows XP or higher support.        
+  * Bug #966320: Disable redirection immediately prior to the native API function call if compiled for Windows XP or higher. However, agent 2.0 supports Windows 2000, and this fix only applies if compiled without Windows 2000 support, but only Windows XP or higher support.        
   * Fix bug #1024077: Agent ensure package timestamp does not exist before creating it, and delete package directory if expired before launching package download and setup tool
   * Fix bug #1021497: Stop downloading if 2/3 of fragment download fail, and wait for next agent launch
   * Fix bug #1021357: Run download at each prolog freq if server ask for download in prolog response, instead to run it at each inventory launch.
-  * Fix bug #1015434: Add better package cleaning process, and check for OCS Agent setup package result before try to compute other packages      
+  * Fix bug #1015434: Add better package cleaning process, and check for OCS Agent setup package result before trying to compute other packages      
   * Fix bug #923112: Event viewer support not repaired when upgrading version. Many Thanks ElNounch for this patch !
   * Fix bug #911696: Add manufacturer code ACI "Asus Computer Inc"
 2.0.4.0
-  * Fix bogus CPU name with lastest CPU, which may not show number of cores and architecture
+  * Fix bogus CPU name with latest CPU, which may not show number of cores and architecture
   * Bug #920044 fixed by same fix as bug #901270
   * Bug #904162 fixed by same fix as bug #901270
   * Bug #909161 fixed by same fix as bug #901270
@@ -97,14 +97,14 @@
   * Fix bug #765893: Use TinyXML 2.6.2 or newer, to prevent memory leak issue when using VBS plugin => agent ran into an infinite loop (refer http://sourceforge.net/tracker/index.php?func=detail&aid=3217501&group_id=13559&atid=313559) 
   * Optimize ExecCommand code, to reduce Handle usage 
   * Fix bug #860551 Migration process from old agent 4000 series fails when eventlog are in use, because ocsservice.dll is not deleted until the next reboot
-  * When agent encounter error dowloading metadata, remove package directory to avoid error message into download tool
+  * When agent encounters error downloading metadata, remove package directory to avoid error message in download tool
   * Fix bug when deploying multiple package with user notification in the same download session
   * Fix bug in NOTIFY mode, where data must be inserted into <CONTENT> XML node
   * Fix Bug #860466: Fix incorrect permission propagation on $AppData\OCS Inventory NG\Agent in some cases
 2.0.2, aka 2.0.2.0
   * Fix Bug #872768: Crash in Registry.cpp - "Run-Time Check Failure #2 - Stack around the variable 'lpstrData' was corrupted."
   * Ensure all array and objects are correctly freed
-  * Fix Bug #859574: Switch to WMI to retreive Bios infos even if DMI access is successfull, but serial or model is not valid
+  * Fix Bug #859574: Switch to WMI to retrieve Bios infos even if DMI access is successful, but serial or model is not valid
   * Fix Bug #435068: Do not register multiple time a monitor with the same serial
   * Fix Bug #860466: Propagate inherited permissions from $AppData\OCS Inventory NG\Agent to Download directory
 2.0.1, aka 2.0.1.0
@@ -112,19 +112,19 @@
 2.0.0.24
   * Fix Bug #805039: Installer creates incomplete ocsinventory.ini
   * Fix Bug #802625: Agent does not store /TAG= on setup if used without /NOW
-  * Fix Bud #754410: "OcsInvetory.exe Application Error" on some systems when using Server or Proxy credentials
+  * Fix Bug #754410: "OcsInventory.exe Application Error" on some systems when using Server or Proxy credentials
   * Fix Bug #800810: Load XML function in TestSysInfo throws exception, thanks to Tommy
   * Setup ignore /NOW if /UPGRADE provided
 2.0.0.23
   * Setup ignore /NOW if /UPGRADE provided
-  * Fix Bud #754410 "OcsInvetory.exe Application Error" on some systems
+  * Fix Bug #754410 "OcsInventory.exe Application Error" on some systems
   * In service, run agent without grabbing stdout/stderr, to avoid dealing with unclosed handles
   * Fix Bug ID 778335 empty values are shown as (null) in XML (produced by string conversion between unicode, ansi and UTF-8)
   * Fix bug #797182 "2 directories was created in APPDATA when upgrade windows agent"
   * When upgrading from agent 1.X, do not copy cacert.pem from INSTDIR to APPDATADIR if file exists into APPDATADIR, to allow changing cacert.pem using Packager
   * Send setup result to server when deploying new OCS agent, without interfering with other package download
   * Fix bug #783611  semicolon added to Type under Bios when using WMI
-  * When using WMI, get S/N from Win32_Bios, and if not availble, try Win32_SystemEnclosure then Win32_Baseboard
+  * When using WMI, get S/N from Win32_Bios, and if not available, try Win32_SystemEnclosure then Win32_Baseboard
   * Fix memory leak in WMI Storage query
   * Delete OCS agent setup done file if found, when cleaning a package
   * Build libcurl using _BIND_TO_CURRENT_VCLIBS_VERSION preprocessor define to bind it to the installed CRT versions, and include libcurl manifest as resource into DLL
@@ -133,7 +133,7 @@
   * Fix memory leak into OCsWmi.dll
   * Fix bogus network adapter description in some Cyrillic OS (perhaps other charset affected)
 2.0.0.18
-  * Uses MS CRT/MFC 9.00.21022.8 on Windows 2000 to fix compatibilty problem of MS11-025 (http://blogs.msdn.com/b/vcblog/archive/2011/04/26/10158277.aspx)
+  * Uses MS CRT/MFC 9.00.21022.8 on Windows 2000 to fix compatibility problem of MS11-025 (http://blogs.msdn.com/b/vcblog/archive/2011/04/26/10158277.aspx)
   * In NOTIFY mode, update only network inventory state, to avoid service launching agent every minute !
   * In NOTIFY mode, do not launch Registry, Download or Ipdiscover capacity, neither VBS or executable plugins (only DLL plugins)
   * Fix some other memory leaks
@@ -168,7 +168,7 @@
 2.0 rc2 aka 2.0.0.13
   * Remove old uninstall key when upgrading
   * Fix setup not writing TAG value when provided  
-  * Fix crash when deployement ZIP contains too much sub directories => uncompress ZIP to system %TEMP%
+  * Fix crash when deployment ZIP contains too many sub directories => uncompress ZIP to system %TEMP%
   * Bug #695843: deleting "&#x...;" encoded binary characters from XML
   * In some cases, logging XML sent crash agent, so disable it while searching a workaround
   * Replace N/A default value by empty string
@@ -176,17 +176,17 @@
   * Upgrade libcurl to 7.21.3
   * Bug #704043:Ensure setup only runs on Windows 2000 and higher, and use Günter Knauf libcurl 7.21.3 binary distribution for Windows 2000 target only.  
   * Fix setup bug when agent series 4000 installed, but never launched (no data file) 
-  * Fix enryption/decryption methods, not really working before :(
+  * Fix encryption/decryption methods, not really working before :(
   * Fix bug appending plugin XML to the inventory XML       
 2.0 rc1 aka 2.0.0.8
   * Bug #438759 and #457595: silent windows installation and OcsService.dll upgrade
 	* On NT 6 and higher (Vista/2008/7/2008R2...), Microsoft Hotfixes are no more stored in the registry. so we have to query WMI to get Hotfixes
 	* Add code to display XML + XSL generated by service to local user
-	* Bug #435850 and #530881: There is changes to DeviceID if 1) Hostname has changed or 2) There is only one MAC, and it has changed or 3) There is 2 or more MACs, and at least 2 has changed has changed
+	* Bug #435850 and #530881: There are changes to DeviceID if 1) Hostname has changed or 2) There is only one MAC, and it has changed or 3) There are 2 or more MACs, and at least 2 have changed
 	* Remove XML cleaning code, no more needed for UTF-8 encoding
 	* Add services and Scheduled job test
 	* Add Unicode to UTF-8 conversion methods
-	* Upgrade to use lastest libraries openssl 1.0.0c and cURL 7.21.2
+	* Upgrade to use latest libraries openssl 1.0.0c and cURL 7.21.2
 	* Fix x64 processor detection
 	* Bug #481332: Add software language, install date, and guid
 	* Add Install Date and Memory Address Width (32 and 64 bits) to software inventory
@@ -194,7 +194,7 @@
 	* Add 64 bits support for OS detection
 	* Add 64 bits software detection
 	* Migrate from old CMarkup XML lib to TinyXML library for UTF-8 support
-	* Use code from CMake to hide command window in deployement	
+	* Use code from CMake to hide command window in deployment	
 	* Add notify mode to agent, to notify server of IP information changes when service detect them, even if inventory is not required
 	* Activate minimal log file ocsinventory.log by default into %PROGRAMDATA%\OCS Inventory NG\Agent
 	* Delay WMI first use until app start, to fix hang under Vista and higher. WMI cannot be used until WinMain starts
@@ -213,8 +213,8 @@
 	* Bug #540789: Remove CAMEL classes for Wrong processor information	
 	* Bug #424219: download.exe segfaults on "max error count reached"	
 	* Bug #661407 and #537378: Complete rewrite of DMI code, to get system slot, port and memory slot 	
-	* Add dynamic plugin load through DLL founds in pugins diretory
+	* Add dynamic plugin load through DLL founds in plugins directory
 	* Add HTTPS and proxy support by using cURL Library through Communication Provider ComHTTP.dll
 2.0 Branch	
-	* Completly rewrite of code in Unicode
+	* Complete rewrite of code in Unicode
 

--- a/OPTIONS.TXT
+++ b/OPTIONS.TXT
@@ -10,7 +10,7 @@
 // THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 // FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-// IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+// IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
 // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
 // OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
@@ -22,56 +22,56 @@
 OCS Inventory NG Windows Agent Command Line Options:
 ----------------------------------------------------
 
-/work_dir:"path to directory"               Agent must use "path to directory" as working dir (this directory may included configuration file) 
+/work_dir:"path to directory"               Agent must use "path to directory" as working dir (this directory may be included in the configuration file)
                                             Default is "%ALLUSERSPROFILE\Application Data\OCS Inventory NG\Agent"
-						
+
 /local=["path to folder"]                   Agent do not contact communication server, and store inventory in xml compressed .ocs file into folder "path to folder"
                                             If no "path to folder" provided, agent assume folder as data folder
 
 /debug[=level]                              Generate a very verbose log file "ocsinventory.log" into agent's install folder
                                             0 => disable verbose logs (default)
                                             1 => enable default verbose logs (default when no level provided provided)
-                                            2 => enable debuging logs
+                                            2 => enable debugging logs
 
 /nosoftware	                                Agent must NOT scan computer for installed software in any case
-	
+
 /notag		                                Agent must NOT prompt user for TAG in any case
-	
+
 /tag="my value"                             Agent must set "my value" as TAG value
-	
-/xml=["path to folder"]                     Agent must store inventory in uncompressed xml format into folder "path to folder" 
+
+/xml=["path to folder"]                     Agent must store inventory in uncompressed xml format into folder "path to folder"
                                             If no "path to folder" provided, agent assume folder as data folder
-	
-/force		                                Always send inventory, even if server do not ask for it (use only for debugging purpose !)
-	
+
+/force		                                Always send inventory, even if server does not ask for it (use only for debugging purpose !)
+
 /ipdisc="network number"	                Agent must launch IP discovery on network "network number" (use only for debugging purpose !)
 
 /ipdisc_lat="number of milliseconds"        Set latency between 2 IP Discover requests to "number of milliseconds"
-    
-/fastip		                                Never wait for latency  between 2 IP Discover requests (use only for debugging purpose !)
-	
+
+/fastip		                                Never wait for latency between 2 IP Discover requests (use only for debugging purpose !)
+
 /hkcu                                       Search also for software under HKEY_CURRENT_USER registry hive (do not work with service as LocalSystem !)
 
 /uid                                        Agent must generate a new unique device ID
-	
+
 
 
 Default Communication Provider HTTP.dll Command Line Options:
 -------------------------------------------------------------
-	
+
 /server=http[s]://server.domain.tld[:port]/ocsinventory
                                             Agent try to connect to Communication Server address and port Listening on http[s]://server.domain.tld[:port]/ocsinventory
-	
-/ssl=0|1                                    When usng SSL connections, 0 => SSL without certificate validation, 1 => SSL with server certificate validation required (needs CA certificate)   
+
+/ssl=0|1                                    When using SSL connections, 0 => SSL without certificate validation, 1 => SSL with server certificate validation required (needs CA certificate)
 
 /ca="path_to_cabundle.pem"                  Path to CA certificate chain file in PEM format, for server certificate validation
-    
+
 /user=username                              Communication Server authentication credentials
 /pwd=password
 
-/proxy_type=0|1|2|3                         Agent proxy use (0 => no, 1 => HTTP proxy, 2 => Socks 4 proxy, 3 => Socks 5 proxy)    
+/proxy_type=0|1|2|3                         Agent proxy use (0 => no, 1 => HTTP proxy, 2 => Socks 4 proxy, 3 => Socks 5 proxy)
 
-/proxy=proxy_address                        Proxy server address (without protocol !)                        
+/proxy=proxy_address                        Proxy server address (without protocol !)
 /proxy_port=port                            Proxy server port
 
 /proxy_user=username                        Proxy authentication credentials
@@ -82,24 +82,24 @@ Default Communication Provider HTTP.dll Command Line Options:
 Configuration file:
 -------------------
 
-Some command line options can be store into configuration file. Default is assumed to be ocsinventory.ini into agent's data folder, usually "%ALLUSERSPROFILE%\Application Data\OCS Inventory NG\Agent".
-Agent can create this cnfiguration using /save_conf command line switch, to allow encrypting into config file username and password. 
+Some command line options can be stored in the configuration file. Default is assumed to be ocsinventory.ini in the agent's data folder, usually "%ALLUSERSPROFILE%\Application Data\OCS Inventory NG\Agent".
+Agent can create this configuration using /save_conf command line switch, to allow encrypting into config file username and password.
 
 Here is a sample configuration file to talk with a server on local computer.
 
 [OCS Inventory Agent]
 ; OCS Inventory NG Agent features
-; Enable debugging mode (0 => disabled, 1 => enabled, 2=> trace all) 
+; Enable debugging mode (0 => disabled, 1 => enabled, 2=> trace all)
 Debug=1
 ; Enable local inventory mode (path to folder to store .ocs file => enabled,
-; empty => disabled) 
+; empty => disabled)
 Local=
-; Enable agent scanning HKEY_CURRENT_USER hive for printers and sofware
-; (0 => disabled, 1 => enabled) 
+; Enable agent scanning HKEY_CURRENT_USER hive for printers and software
+; (0 => disabled, 1 => enabled)
 HKCU=0
-; Disable scanning computer for installed software (0 => software scan allowed, 1 => disabled) 
+; Disable scanning computer for installed software (0 => software scan allowed, 1 => disabled)
 NoSOFTWARE=0
-; Disable prompting user for TAG value (0 => prompt allowed, 1 => disabled) 
+; Disable prompting user for TAG value (0 => prompt allowed, 1 => disabled)
 NoTAG=0
 ; Force agent launching IpDiscover on specified network (network address => enabled,
 ; empty disabled)
@@ -135,6 +135,6 @@ ProxyAuthRequired=
 ProxyUser=
 ProxyPwd=
 
- 
+
 [OCS Inventory Service]
 PROLOG_FREQ=1

--- a/README.TXT
+++ b/README.TXT
@@ -10,7 +10,7 @@
 // THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
 // INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
 // FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-// IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+// IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 // SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
 // PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
 // OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
@@ -25,14 +25,14 @@ REQUIREMENTS
 
 - Microsoft Visual C++ 2008 SP1 or higher
 - Perl 5.8 or newer for building dependancies (you can use XAMPP perl addon)
-- Source code exported from Launchpad Bazaar repository. 
+- Source code exported from Launchpad Bazaar repository.
   svn co https://
 
 
 BUILDING DEPENDANCIES
 =====================
 
-OCS Inventory NG Agent for Windows needs followong libraries:
+OCS Inventory NG Agent for Windows needs following libraries:
 
 - zlib 1.2.5 or newer (www.zlib.net)
 - openssl 1.0.0c or newer (www.openssl.org)
@@ -42,7 +42,7 @@ OCS Inventory NG Agent for Windows needs followong libraries:
 - ZipArchive GPL Edition 4.0.1 or newer (http://www.artpol-software.com)
 
 Uncompress sources of these libraries into directory "External_Deps" to create
-the followong directory structures.
+the following directory structures.
 - External_Deps\Zlib-1.2.5
 - External_Deps\openssl-1.0.0c
 - External_Deps\curl-7.21.3
@@ -52,24 +52,24 @@ the followong directory structures.
 
 Open "ZipArchive.sln" Visual C++ 2008 solution in folder
 "External_Deps\ZipArchive", select configuration "Release Unicode STL MD DLL"
-for plateform Win32, and edit project properties. Add 
-_BIND_TO_CURRENT_VCLIBS_VERSION preprocessor define to "Configuration 
-properties / C/C++ / Preprocessor" section to automatically bind DLL to Visual 
+for platform Win32, and edit project properties. Add
+_BIND_TO_CURRENT_VCLIBS_VERSION preprocessor define to "Configuration
+properties / C/C++ / Preprocessor" section to automatically bind DLL to Visual
 C++ 2008 SP1 CRT and MFC versions (for more explanation, see Jochen Kalmbach's Blog
 http://blog.kalmbach-software.de/2009/05/27/deployment-of-vc2008-apps-without-installing-anything/)
 Save and build to create unicode DLL for ZipArchive Library.
 
-Script for building dependancy automatically fixess cURL and net-snmp Makefiles for Visual C++ 2008,
+Script for building dependancy automatically fixes cURL and net-snmp Makefiles for Visual C++ 2008,
 by adding "/D_BIND_TO_CURRENT_VCLIBS_VERSION" to the CFLAGS. As is, libcurl and net-snmp
-DLL will be binded to lastest Visual C++ 2008 SP1 CRT versions.
+DLL will be bound to latest Visual C++ 2008 SP1 CRT versions.
 
-For Zlib, OpenSSL and TinyXML, compiling using _BIND_TO_CURRENT_VCLIBS_VERSION 
+For Zlib, OpenSSL and TinyXML, compiling using _BIND_TO_CURRENT_VCLIBS_VERSION
 preprocessor define is done through the call of build file "OCS_Make_Required_Libs.bat".
 
 
 Edit script "OCS_Make_Required_Libs.bat" to meet your need, especially
 
-- Set path to MS Visual C++ 2008, for example 
+- Set path to MS Visual C++ 2008, for example
   set VC_PATH=C:\Program Files\Microsoft Visual Studio 9.0\VC
 - Set path to MS Windows SDK, needed to build cURL, for example with VC++ 2008
   set WINDOWS_SDK_PATH="C:\Program Files\Microsoft SDKs\Windows\v6.0A"
@@ -89,12 +89,12 @@ Edit script "OCS_Make_Required_Libs.bat" to meet your need, especially
 Then, launch script "OCS_Make_Required_Libs.bat" to create all libs and prepare for building OCS agent.
 
 
-BUIDLING AGENT
+BUILDING AGENT
 ==============
 
 You need Visual C++ 2008, which includes MS Windows SDK 6.0A.
 
-Open solution "OCSInventory.sln", select project "Agent" and buid it !
+Open solution "OCSInventory.sln", select project "Agent" and build it !
 
 See Options.txt for agent's command line switches.
 

--- a/ocsinventory.ini.sample
+++ b/ocsinventory.ini.sample
@@ -1,14 +1,14 @@
 [OCS Inventory Agent]
 ; OCS Inventory NG Agent features
-; Enable debugging mode (0 => disabled, 1 => enabled, 2=> trace all) 
+; Enable debugging mode (0 => disabled, 1 => enabled, 2=> trace all)
 Debug=1
 ; Enable local inventory mode (path to folder to store .ocs file => enabled,
-; empty => disabled) 
+; empty => disabled)
 Local=
-; Enable agent scanning HKEY_CURRENT_USER hive for printers and sofware
-; (0 => disabled, 1 => enabled) 
+; Enable agent scanning HKEY_CURRENT_USER hive for printers and software
+; (0 => disabled, 1 => enabled)
 HKCU=0
-; Disable prompting user for TAG value (0 => prompt allowed, 1 => disabled) 
+; Disable prompting user for TAG value (0 => prompt allowed, 1 => disabled)
 NoTAG=0
 ; Force agent launching IpDiscover on specified network (network address => enabled,
 ; empty disabled)
@@ -43,6 +43,6 @@ ProxyAuthRequired=
 ; Proxy authentication credentials (encrypted)
 ProxyUser=
 ProxyPwd=
- 
+
 [OCS Inventory Service]
 PROLOG_FREQ=1


### PR DESCRIPTION
describing the Windows Agent.
These are just text typos that do not effect anything other than the written quality of the docs in English. I made the changes while starting to read about the agent.
Are you interested to have these sort of changes? I am happy to make such corrections as I find them when looking through code and examples...