### PR TITLE
Fix bug Windows 8 and newer WINPRODKEY does not match

### DIFF
--- a/SysInfo/Registry.cpp
+++ b/SysInfo/Registry.cpp
@@ -3656,7 +3656,9 @@ BOOL CRegistry::GetWindowsProductKey(CString &csProductKey)
 {	
 	char KeyChars[24] = {'B','C','D','F','G','H','J','K','M','P','Q','R','T','V','W','X','Y','2','3','4','6','7','8','9'};
 	char Result[30];
-
+	int isWin8;
+	int Last;
+	
 	CString csKeyPath, csValueName, csValue4Name;
 
 	// Registry access variables
@@ -3695,6 +3697,11 @@ BOOL CRegistry::GetWindowsProductKey(CString &csProductKey)
 			// We need 15 bytes from $35 in BinaryKey
 			memcpy( BinaryKey, &Data[0x34], sizeof(BinaryKey));
 
+			
+			isWin8=(BinaryKey[14]/6) & 1;
+			BinaryKey[14]=((BinaryKey[14] & 0xF7) | ((isWin8 & 2) * 4));
+			
+			
 			for( i=24; i>=0; i-- ){
 				A = 0;
 				// decoding the current symbol
@@ -3706,6 +3713,21 @@ BOOL CRegistry::GetWindowsProductKey(CString &csProductKey)
 				DecodedKey[i] = KeyChars[A];
 			}
 
+			if (isWin8 = 1)
+			{
+				for( i=0; i<4; i++ ){
+					DecodedKey[i] = DecodedKey[i+1];
+				}
+				DecodedKey[4]='N';
+							
+				if (Last = 0){
+					for( i=24; i>=1; i-- ){
+						DecodedKey[i] = DecodedKey[i-1];
+					}
+					 DecodedKey[0]='N';
+				}
+			}
+			
 			
 			j=0;
 			for( i=0; i<25; i++ ){

--- a/SysInfo/Registry.cpp
+++ b/SysInfo/Registry.cpp
@@ -3711,6 +3711,7 @@ BOOL CRegistry::GetWindowsProductKey(CString &csProductKey)
 					A = A % 24;
 				}
 				DecodedKey[i] = KeyChars[A];
+				Last=A;
 			}
 
 			if (isWin8 = 1)

--- a/SysInfo/Registry.cpp
+++ b/SysInfo/Registry.cpp
@@ -3715,10 +3715,10 @@ BOOL CRegistry::GetWindowsProductKey(CString &csProductKey)
 
 			if (isWin8 = 1)
 			{
-				for( i=0; i<4; i++ ){
+				for( i=0; i<Last; i++ ){
 					DecodedKey[i] = DecodedKey[i+1];
 				}
-				DecodedKey[4]='N';
+				DecodedKey[Last]='N';
 							
 				if (Last = 0){
 					for( i=24; i>=1; i-- ){


### PR DESCRIPTION
Solving the problem with the keys in Windows 8 and 10, tested on 17 computers.