### PR TITLE
register service even if it exists in order to quote the path with spaces

### DIFF
--- a/NSIS_agent_setup/OCS-NG_Windows_Agent_Setup.nsi
+++ b/NSIS_agent_setup/OCS-NG_Windows_Agent_Setup.nsi
@@ -837,7 +837,7 @@ Function InstallService
     	    Pop $R0
 	        StrCpy $logBuffer "Result: $R0.$\r$\n"
 	        Call Write_Log
-        ${EndIf}
+        ; ${EndIf}
     ${EndIf}
 	; Restore used register
 	Pop $R0

--- a/NSIS_agent_setup/OCS-NG_Windows_Agent_Setup.nsi
+++ b/NSIS_agent_setup/OCS-NG_Windows_Agent_Setup.nsi
@@ -827,10 +827,10 @@ Function InstallService
 	    ; check if NT service was previously installed
         services::IsServiceInstalled "${PRODUCT_SERVICE_NAME}"
         Pop $R0
-        ${If} "$R0" == "Yes"
-            StrCpy $logBuffer "Yes$\r$\nNothing to do to register ${PRODUCT_SERVICE_NAME} into Windows Service Manager.$\r$\n"
-            Call Write_Log
-        ${Else}
+        ; ${If} "$R0" == "Yes"
+        ;    StrCpy $logBuffer "Yes$\r$\nNothing to do to register ${PRODUCT_SERVICE_NAME} into Windows Service Manager.$\r$\n"
+        ;    Call Write_Log
+        ; ${Else}
             StrCpy $logBuffer "No$\r$\nRegistering ${PRODUCT_SERVICE_NAME} into Windows Service Manager..."
             Call Write_Log
     	    nsExec::ExecToLog "$INSTDIR\OcsService.exe -install"


### PR DESCRIPTION
PR 46 is in the released 2.3.1 version, unfortunately, it does not quote the path if service is already installed. You have to uninstall older agent first, which is unfortunate, as you cannot mass upgrade (deploy).

This is my try to fix it. Untested.