### PR TITLE
Fix #47: Better retrieving of MAC addresses

### DIFF
--- a/SysInfo/IPHelper.cpp
+++ b/SysInfo/IPHelper.cpp
@@ -173,6 +173,13 @@ BOOL CIPHelper::GetNetworkAdapters(CNetworkAdapterList *pList)
 	for (dwIndex = 0; dwIndex < pIfTable->dwNumEntries; dwIndex++)
 	{
 		pIfEntry = (MIB_IFROW *)&(pIfTable->table[dwIndex]);
+
+		// next entry if MAC empty
+		if (pIfEntry->bPhysAddr[0] == 0 && pIfEntry->bPhysAddr[1] == 0 &&
+			pIfEntry->bPhysAddr[2] == 0 && pIfEntry->bPhysAddr[3] == 0 &&
+			pIfEntry->bPhysAddr[4] == 0 && pIfEntry->bPhysAddr[5] == 0)
+			continue;
+
 		if (pIfEntry->dwType != IF_TYPE_SOFTWARE_LOOPBACK)
 		{
 			//if Network card is desabled


### PR DESCRIPTION
The behavior is currently bad because often empty MAC address are
retrieved. With this fix, we exclude empty MAC.