### PR TITLE
Update version ocs to 2.3.1.1

### DIFF
--- a/Agent/OCSInventory.rc
+++ b/Agent/OCSInventory.rc
@@ -34,8 +34,8 @@ IDR_MAINFRAME           ICON                    "res\\OCSInventory.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -53,13 +53,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG Agent"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG Agent"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "OCSInventory.exe"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "OCSInventory.exe"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2.3.1.1
+  * Fix memory leak
+  * Add Network disconnected status on inventory
+  * Fix bug encoded translation WMI S/N Windows 7
+  * Update Network adapter's description to support unicode characters
+
 2.3.1.0
   * Update deprecated functions
   * Add PowerShell support for plugins

--- a/ComHTTP/HTTP.rc
+++ b/ComHTTP/HTTP.rc
@@ -25,8 +25,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -44,13 +44,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG Communication Provider"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG cURL Communication Provider"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "ComHTTP.dll"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "ComHTTP.dll"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/Download/Download.rc
+++ b/Download/Download.rc
@@ -28,8 +28,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -47,13 +47,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG Package Download and Setup Tool"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG Package Download and Setup Tool"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "Download.exe"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "Download.exe"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/NSIS_agent_setup/OCS-NG_Windows_Agent_Setup.nsi
+++ b/NSIS_agent_setup/OCS-NG_Windows_Agent_Setup.nsi
@@ -12,7 +12,7 @@ setcompressor /SOLID lzma
 
 ; HM NIS Edit Wizard helper defines
 !define PRODUCT_NAME "OCS Inventory NG Agent"
-!define PRODUCT_VERSION "2.3.1.0"
+!define PRODUCT_VERSION "2.3.1.1"
 !define PRODUCT_PUBLISHER "OCS Inventory NG Team"
 !define PRODUCT_WEB_SITE "http://www.ocsinventory-ng.org"
 !define PRODUCT_DIR_REGKEY "Software\Microsoft\Windows\CurrentVersion\App Paths\OCSInventory.exe"

--- a/OCSInventory Front/OCSInventory Front.rc
+++ b/OCSInventory Front/OCSInventory Front.rc
@@ -25,8 +25,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -44,13 +44,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG Framework Provider"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG Framework Provider"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "OCSInventory Front.dll"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "OCSInventory Front.dll"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/OcsNotifyUser/OcsNotifyUser.rc
+++ b/OcsNotifyUser/OcsNotifyUser.rc
@@ -385,8 +385,8 @@ IDR_MAINFRAME           ICON                    "..\\Agent\\res\\OCSInventory.ic
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -404,13 +404,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG User Notification Provider"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG User Notification Provider"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "OcsNotifyUser.exe"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "OcsNotifyUser.exe"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/OcsSystray/OcsSystray.rc
+++ b/OcsSystray/OcsSystray.rc
@@ -388,8 +388,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -407,13 +407,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG Systray applet"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG Systray applet"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "OcsSystray.exe"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "OcsSystray.exe"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/OcsWmi/OcsWmi.rc
+++ b/OcsWmi/OcsWmi.rc
@@ -25,8 +25,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -44,13 +44,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG WMI Provider"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG WMI Provider"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "OcsWmi.dll"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "OcsWmi.dll"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/Service/Service.rc
+++ b/Service/Service.rc
@@ -25,8 +25,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -44,13 +44,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG Service"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG Service"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "OcsService.exe"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "OcsService.exe"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/SysInfo/SysInfo.rc
+++ b/SysInfo/SysInfo.rc
@@ -25,8 +25,8 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_DEFAULT
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -44,13 +44,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG System Provider"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG System Provider"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "SysInfo.dll"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "SysInfo.dll"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/TestSysInfo/TestSysInfo.rc
+++ b/TestSysInfo/TestSysInfo.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,3,1,0
- PRODUCTVERSION 2,3,1,0
+ FILEVERSION 2,3,1,1
+ PRODUCTVERSION 2,3,1,1
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -70,13 +70,13 @@ BEGIN
             VALUE "Comments", "OCS Inventory NG System Informations Testing tool"
             VALUE "CompanyName", "OCS Inventory NG"
             VALUE "FileDescription", "OCS Inventory NG System Informations Testing tool"
-            VALUE "FileVersion", "2.3.1.0"
+            VALUE "FileVersion", "2.3.1.1"
             VALUE "InternalName", "TestSysInfo.exe"
             VALUE "LegalCopyright", "Open Source Software released under GNU General Public License V2"
             VALUE "LegalTrademarks", "http://www.ocsinventory-ng.org"
             VALUE "OriginalFilename", "TestSysInfo.exe"
             VALUE "ProductName", "OCS Inventory NG Windows Agent"
-            VALUE "ProductVersion", "2.3.1.0"
+            VALUE "ProductVersion", "2.3.1.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/logon/OcsLogon.nsi
+++ b/logon/OcsLogon.nsi
@@ -12,7 +12,7 @@ setcompressor /SOLID lzma
 
 ; Version informations
 !define PRODUCT_NAME "OCS Inventory NG Logon Installer"
-!define PRODUCT_VERSION "2.3.1.0"
+!define PRODUCT_VERSION "2.3.1.1"
 !define PRODUCT_PUBLISHER "OCS Inventory NG Team"
 !define PRODUCT_WEB_SITE "http://www.ocsinventory-ng.org"
 


### PR DESCRIPTION
## Description
Update OCS version to 2.3.1.1

#### General informations
Operating system :  Windows 10

#### OCS Inventory informations
Windows agent version : 2.3.1.0
