### PR TITLE
Fix powershell process to stay up after script execution

### DIFF
--- a/Agent/CapExecute.cpp
+++ b/Agent/CapExecute.cpp
@@ -81,7 +81,7 @@ BOOL CCapExecute::execute( const int bScript, LPCTSTR lpstrPath)
 			cmProcess.setOutputFile( csOutputFile);
 			// Execute script
 			if (bScript == PWSHELL){
-				csCommand.Format(_T("Powershell.exe -ExecutionPolicy Unrestricted -File \"%s\""), cFinder.GetFilePath());
+				csCommand.Format(_T("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -ExecutionPolicy unrestricted -Command \"& {%s; [Environment]::Exit(1)}\""), cFinder.GetFilePath());
 			}
 			else if (bScript == VBS){
 				csCommand.Format(_T("cscript /nologo \"%s\""), cFinder.GetFilePath());


### PR DESCRIPTION
## Status
**READY**

## Description
Sometimes powershell will have a bad behavior and will stay on execution.
Thus, the agent will stay waiting and will be loop on inventory.

The solution is to send an exit code to the environnement itself and not on powershell script.
```& {%s; [Environment]::Exit(1)}```