### PR TITLE
Fix the CDMI::DmiString() function

### DIFF
--- a/External_Deps/OCS_Make_Required_Libs.bat
+++ b/External_Deps/OCS_Make_Required_Libs.bat
@@ -122,6 +122,8 @@ cd "%CURL_PATH%"
 Rem Disable LDAP support, not needed in OCS Inventory NG Agent
 set WINDOWS_SSPI=0
 cd ..\winbuild
+Rem Fix cURL DLL config for correct OpenSSL include path
+perl.exe -pi.bak -e "s#\$\(SSL_PATH\)\\include#\$\(SSL_PATH\)#g" MakefileBuild.vc
 Rem Fix cURL DLL config for MS Visual C++ with lastest Service Pack ( -D_BIND_TO_CURRENT_VCLIBS_VERSION)
 Rem perl.exe -pi.bak -e "s# /DBUILDING_LIBCURL# /DBUILDING_LIBCURL /D_BIND_TO_CURRENT_VCLIBS_VERSION#g" Makefile.vc12
 Rem Build cURL dll using OpenSSL Dlls and Zlib dll
@@ -180,11 +182,16 @@ title OCS Inventory NG Agent for Windows - Building ZipArchive DLL...
 echo.
 echo *************************************************************************
 echo *                                                                       *
-echo * Preparing for OCS Inventory NG : Configuring ZipArchive DLL...        *
+echo * Preparing for OCS Inventory NG : Building ZipArchive DLL...           *
 echo *                                                                       *
 echo *************************************************************************
 echo.
-cd "%ZIP_PATH%\Release Unicode STL MD DLL"
+cd "%ZIP_PATH%"
+Rem Fix ZipArchive DLL config for MS Visual C++ with lastest Service Pack
+perl.exe -pi.bak -e "s#_CRT_RAND_S;%%\(PreprocessorDefinitions\)</PreprocessorDefinitions>#_CRT_RAND_S;_BIND_TO_CURRENT_VCLIBS_VERSION;%%\(PreprocessorDefinitions\)</PreprocessorDefinitions>#g" ZipArchive.vcxproj
+devenv ZipArchive.sln /Build "Release Unicode STL MD DLL|Win32"
+if ERRORLEVEL 1 goto ERROR
+cd "Release Unicode STL MD DLL"
 Rem copy libs to use them in OCS
 copy "ZipArchive.lib" ..\..
 copy "ZipArchive.dll" ..\..\..\Release
@@ -228,7 +235,6 @@ echo *                                                                       *
 echo * Here is some common errors:                                           *
 echo * - Have you reviewed paths at the beginning of this batch file ?       *
 echo * - Have you updated Visual C++ version in cURL Makefile ?              *
-echo * - Have you build ZipArchive "Release Unicode STL MD DLL" ?            *
 echo *                                                                       *
 echo *************************************************************************
 

--- a/External_Deps/OCS_Make_Required_Libs_x64.bat
+++ b/External_Deps/OCS_Make_Required_Libs_x64.bat
@@ -59,7 +59,7 @@ cd "%ZLIB_PATH%"
 Rem clean nmake 
 nmake Win32\Makefile.msc clean
 Rem Build Zlib using precompiled asm code for MS Visual C++ with lastest Service Pack ( -D_BIND_TO_CURRENT_VCLIBS_VERSION)
-nmake /NOLOGO -f Win32\Makefile.msc AS=ml64 LOC="-DASMV -DASMINF -D_BIND_TO_CURRENT_VCLIBS_VERSION" OBJA="inffasx64.obj gvmat64.obj inffas8664.obj"
+nmake /NOLOGO -f Win32\Makefile.msc AS=ml64 LOC="-DASMV -DASMINF -D_BIND_TO_CURRENT_VCLIBS_VERSION -I." OBJA="inffasx64.obj gvmat64.obj inffas8664.obj"
 if ERRORLEVEL 1 goto ERROR
 
 Rem copy libs to use them in OCS
@@ -124,6 +124,8 @@ cd "%CURL_PATH%"
 Rem Disable LDAP support, not needed in OCS Inventory NG Agent
 set WINDOWS_SSPI=0
 cd ..\winbuild
+Rem Fix cURL DLL config for correct OpenSSL include path
+perl.exe -pi.bak -e "s#\$\(SSL_PATH\)\\include#\$\(SSL_PATH\)#g" MakefileBuild.vc
 Rem Fix cURL DLL config for MS Visual C++ with lastest Service Pack ( -D_BIND_TO_CURRENT_VCLIBS_VERSION)
 Rem perl.exe -pi.bak -e "s# /DBUILDING_LIBCURL# /DBUILDING_LIBCURL /D_BIND_TO_CURRENT_VCLIBS_VERSION#g" Makefile.vc12
 Rem Build cURL dll using OpenSSL Dlls and Zlib dll
@@ -182,11 +184,16 @@ title OCS Inventory NG Agent for Windows - Building ZipArchive DLL...
 echo.
 echo *************************************************************************
 echo *                                                                       *
-echo * Preparing for OCS Inventory NG : Configuring ZipArchive DLL...        *
+echo * Preparing for OCS Inventory NG : Building ZipArchive DLL...           *
 echo *                                                                       *
 echo *************************************************************************
 echo.
-cd "%ZIP_PATH%\x64\Release Unicode STL MD DLL"
+cd "%ZIP_PATH%"
+Rem Fix ZipArchive DLL config for MS Visual C++ with lastest Service Pack
+perl.exe -pi.bak -e "s#_CRT_RAND_S;%%\(PreprocessorDefinitions\)</PreprocessorDefinitions>#_CRT_RAND_S;_BIND_TO_CURRENT_VCLIBS_VERSION;%%\(PreprocessorDefinitions\)</PreprocessorDefinitions>#g" ZipArchive.vcxproj
+devenv ZipArchive.sln /Build "Release Unicode STL MD DLL|x64"
+if ERRORLEVEL 1 goto ERROR
+cd "x64\Release Unicode STL MD DLL"
 Rem copy libs to use them in OCS
 copy "ZipArchive.lib" ..\..\..
 copy "ZipArchive.dll" ..\..\..\..\Release
@@ -230,7 +237,6 @@ echo *                                                                       *
 echo * Here is some common errors:                                           *
 echo * - Have you reviewed paths at the beginning of this batch file ?       *
 echo * - Have you updated Visual C++ version in cURL Makefile ?              *
-echo * - Have you build ZipArchive "Release Unicode STL MD DLL" ?            *
 echo *                                                                       *
 echo *************************************************************************
 

--- a/SysInfo/DMI.cpp
+++ b/SysInfo/DMI.cpp
@@ -47,10 +47,10 @@ LPCTSTR CDMI::DmiString(DmiHeader* dmi, UCHAR id)
 	static CString cstr;
 	char *p = (char *)dmi;
 
+	p += dmi->Length;
+
 	if (id == 0)
 		return _T( "");
-
-	p += dmi->Length;
 
 	while(id > 1 && *p)
 	{

--- a/SysInfo/DMI.cpp
+++ b/SysInfo/DMI.cpp
@@ -47,6 +47,9 @@ LPCTSTR CDMI::DmiString(DmiHeader* dmi, UCHAR id)
 	static CString cstr;
 	char *p = (char *)dmi;
 
+	if (id == 0)
+		return _T( "");
+
 	p += dmi->Length;
 
 	while(id > 1 && *p)


### PR DESCRIPTION
## Status
**READY**

## Description
Update SysInfo/DMI.cpp. Fix the CDMI::DmiString() function. It worked incorrectly if the second arg was 0.

## Related Issues
#26

## Todos
- [ ] Tests

## Test environment
SMBIOS with Asset Tag Number byte is zero

#### General information
Operating system :  Windows 8.1, Windows 10

#### OCS Inventory information
Windows agent version : 2.6

## Deploy Notes
1. CDMI::GetBios()
2. CDMI::GetSystemInformation()
3. CDMI::GetBaseBoard()
4. CDMI::GetSystemEnclosure()
5. CDMI::GetSystemPorts()
6. CDMI::GetSystemSlots()
7. CDMI::GetMemorySlots()

## Impacted Areas in Application
CDMI class in Sysinfo library.
