### PR TITLE
Fix the CDMI::DmiString() function

### DIFF
--- a/SysInfo/DMI.cpp
+++ b/SysInfo/DMI.cpp
@@ -49,6 +49,9 @@ LPCTSTR CDMI::DmiString(DmiHeader* dmi, UCHAR id)
 
 	p += dmi->Length;
 
+	if (id == 0)
+		return _T( "");
+
 	while(id > 1 && *p)
 	{
 		p += strlen(p);


### PR DESCRIPTION
## Status
**READY**

## Description
Update SysInfo/DMI.cpp. Fix the CDMI::DmiString() function. It worked incorrectly if the second arg was 0.

## Related Issues
#26

## Todos
- [ ] Tests

## Test environment
SMBIOS with Asset Tag Number byte is zero

#### General information
Operating system :  Windows 8.1, Windows 10

#### OCS Inventory information
Windows agent version : 2.6

## Deploy Notes
1. CDMI::GetBios()
2. CDMI::GetSystemInformation()
3. CDMI::GetBaseBoard()
4. CDMI::GetSystemEnclosure()
5. CDMI::GetSystemPorts()
6. CDMI::GetSystemSlots()
7. CDMI::GetMemorySlots()

## Impacted Areas in Application
CDMI class in Sysinfo library.